### PR TITLE
Add algorithm verification to JWT middleware

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -32,6 +32,9 @@ func JWTMiddleware(secret string) fiber.Handler {
 		}
 		tokenString := parts[1]
 		token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
+			if t.Method.Alg() != jwt.SigningMethodHS256.Alg() {
+				return nil, fiber.ErrUnauthorized
+			}
 			return []byte(secret), nil
 		})
 		if err != nil || !token.Valid {


### PR DESCRIPTION
## Summary
- ensure JWT middleware only accepts HS256 signed tokens

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6845e87459f08327a8cb3bb9982b2851