### PR TITLE
Add role-based authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ export JWT_SECRET=your-jwt-secret
 
 The application reads `configs/config.yaml` for defaults but any environment variable above will override the values in the file.
 
+Users registered via `/auth/register` are created with the `user` role by default. Access to invoice endpoints now requires either the `user` or `admin` role.
+
 Run the project with:
 
 ```bash

--- a/internal/auth/domain/auth.go
+++ b/internal/auth/domain/auth.go
@@ -8,6 +8,7 @@ type User struct {
 	ID        uint      `gorm:"primaryKey;autoIncrement" json:"id"`
 	Username  string    `gorm:"unique;not null" json:"username"`
 	Password  string    `gorm:"not null" json:"-"`
+	Role      string    `gorm:"type:varchar(20);default:'user'" json:"role"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/internal/auth/repository/auth_pg.go
+++ b/internal/auth/repository/auth_pg.go
@@ -32,6 +32,9 @@ func (r *authPG) CreateUser(user *domain.User) error {
 		return err
 	}
 	user.Password = string(hashed)
+	if user.Role == "" {
+		user.Role = "user"
+	}
 	return r.db.Create(user).Error
 }
 

--- a/internal/auth/usecase/auth_usecase.go
+++ b/internal/auth/usecase/auth_usecase.go
@@ -59,6 +59,7 @@ func (u *authUC) Register(username, password string) error {
 	user := &domain.User{
 		Username: username,
 		Password: password,
+		Role:     "user",
 	}
 	return u.repo.CreateUser(user)
 }
@@ -87,12 +88,12 @@ func (u *authUC) Login(username, password string) (string, string, error) {
 		return "", "", errors.New("invalid credentials")
 	}
 	// สร้าง access token
-	accessToken, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Username, u.accessExpiry)
+	accessToken, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Username, user.Role, u.accessExpiry)
 	if err != nil {
 		return "", "", err
 	}
 	// สร้าง refresh token (random string หรือ JWT ก็ได้ ในที่นี้ใช้ JWT ง่าย ๆ)
-	refreshToken, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Username, u.refreshExpiry)
+	refreshToken, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Username, user.Role, u.refreshExpiry)
 	if err != nil {
 		return "", "", err
 	}
@@ -127,11 +128,11 @@ func (u *authUC) RefreshAccessToken(oldRefreshToken string) (string, string, err
 	}
 	// ถ้า valid ก็สร้าง access + refresh ใหม่
 	user := &existing.User
-	newAccess, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Username, u.accessExpiry)
+	newAccess, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Username, user.Role, u.accessExpiry)
 	if err != nil {
 		return "", "", err
 	}
-	newRefresh, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Username, u.refreshExpiry)
+	newRefresh, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Username, user.Role, u.refreshExpiry)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/invoice/delivery/http/invoice_handler.go
+++ b/internal/invoice/delivery/http/invoice_handler.go
@@ -58,7 +58,7 @@ func (h *InvoiceHandler) List(c *fiber.Ctx) error {
 }
 
 func (h *InvoiceHandler) RegisterRoutes(app *fiber.App) {
-	api := app.Group("/invoices", middleware.JWTMiddleware(h.authSecret))
+	api := app.Group("/invoices", middleware.JWTMiddleware(h.authSecret), middleware.RequireRoles("user", "admin"))
 	api.Post("/", h.Create)
 	api.Get("/", h.List)
 	api.Get("/:id", h.GetByID)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -9,10 +9,12 @@ import (
 )
 
 // GenerateJWTWithExpiry สร้าง JWT ระบุอายุเป็น duration ได้
-func GenerateJWTWithExpiry(secret string, userID uint, username string, expiry time.Duration) (string, error) {
+// GenerateJWTWithExpiry creates a JWT containing the user's ID, username and role
+func GenerateJWTWithExpiry(secret string, userID uint, username, role string, expiry time.Duration) (string, error) {
 	claims := jwt.MapClaims{
 		"user_id":  userID,
 		"username": username,
+		"role":     role,
 		"exp":      time.Now().Add(expiry).Unix(),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -41,9 +43,12 @@ func JWTMiddleware(secret string) fiber.Handler {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid or expired token"})
 		}
 		claims := token.Claims.(jwt.MapClaims)
-		// อ่าน user_id จาก claims ใส่ลง Locals
+		// อ่าน user_id และ role จาก claims ใส่ลง Locals
 		if userID, ok := claims["user_id"].(float64); ok {
 			c.Locals("user_id", uint(userID))
+		}
+		if role, ok := claims["role"].(string); ok {
+			c.Locals("role", role)
 		}
 		c.Locals("username", claims["username"].(string))
 		return c.Next()

--- a/pkg/middleware/role.go
+++ b/pkg/middleware/role.go
@@ -1,0 +1,19 @@
+package middleware
+
+import "github.com/gofiber/fiber/v2"
+
+// RequireRoles ensures the current user has one of the allowed roles.
+func RequireRoles(roles ...string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		userRole, ok := c.Locals("role").(string)
+		if !ok {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "forbidden"})
+		}
+		for _, r := range roles {
+			if r == userRole {
+				return c.Next()
+			}
+		}
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "forbidden"})
+	}
+}


### PR DESCRIPTION
## Summary
- extend user model with role field
- include role in JWT tokens
- add middleware to enforce roles
- restrict invoice routes to user/admin roles
- document new role behavior in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6845ebe11fb4832799fe0e0795c556d2