### PR TITLE
Add role-based authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ export DB_USER=postgres
 export DB_PASSWORD=your-password
 export DB_NAME=invoice_db
 export JWT_SECRET=your-jwt-secret
+export JWT_ISSUER=invoice_service
+export JWT_AUDIENCE=invoice_api
 ```
 
 The application reads `configs/config.yaml` for defaults but any environment variable above will override the values in the file.
+
+Users registered via `/auth/register` are created with the `user` role by default. Access to invoice endpoints now requires either the `user` or `admin` role.
+JWT tokens now include standard `iss` and `aud` claims derived from `JWT_ISSUER` and `JWT_AUDIENCE`.
 
 Run the project with:
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,6 +58,8 @@ func main() {
 	authUsecase := authUC.NewAuthUsecase(
 		authRepository,
 		cfg.Auth.JWTSecret,
+		cfg.Auth.JWTIssuer,
+		cfg.Auth.JWTAudience,
 		cfg.Auth.JWTExpiryAccessMin,
 		cfg.Auth.JWTExpiryRefreshHours,
 	)
@@ -67,7 +69,7 @@ func main() {
 	// ตระเตรียม Invoice module
 	invoiceRepository := invRepo.NewInvoiceRepository(db)
 	invoiceUsecase := invUC.NewInvoiceUsecase(invoiceRepository)
-	invoiceHandler := invHandler.NewInvoiceHandler(invoiceUsecase, cfg.Auth.JWTSecret)
+	invoiceHandler := invHandler.NewInvoiceHandler(invoiceUsecase, cfg.Auth.JWTSecret, cfg.Auth.JWTIssuer, cfg.Auth.JWTAudience)
 	invoiceHandler.RegisterRoutes(app)
 
 	// สตาร์ทเซิร์ฟเวอร์

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -12,5 +12,7 @@ database:
 auth:
   # JWT secret should be provided via the JWT_SECRET environment variable
   jwt_secret: ""
+  jwt_issuer: "invoice_service"
+  jwt_audience: "invoice_api"
   jwt_expiry_access_minutes: 15
   jwt_expiry_refresh_hours: 24

--- a/internal/auth/domain/auth.go
+++ b/internal/auth/domain/auth.go
@@ -8,6 +8,7 @@ type User struct {
 	ID        uint      `gorm:"primaryKey;autoIncrement" json:"id"`
 	Username  string    `gorm:"unique;not null" json:"username"`
 	Password  string    `gorm:"not null" json:"-"`
+	Role      string    `gorm:"type:varchar(20);default:'user'" json:"role"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/internal/auth/repository/auth_pg.go
+++ b/internal/auth/repository/auth_pg.go
@@ -32,6 +32,9 @@ func (r *authPG) CreateUser(user *domain.User) error {
 		return err
 	}
 	user.Password = string(hashed)
+	if user.Role == "" {
+		user.Role = "user"
+	}
 	return r.db.Create(user).Error
 }
 

--- a/internal/invoice/delivery/http/invoice_handler.go
+++ b/internal/invoice/delivery/http/invoice_handler.go
@@ -10,14 +10,18 @@ import (
 )
 
 type InvoiceHandler struct {
-	invUC      usecase.InvoiceUsecase
-	authSecret string
+	invUC       usecase.InvoiceUsecase
+	authSecret  string
+	jwtIssuer   string
+	jwtAudience string
 }
 
-func NewInvoiceHandler(invUC usecase.InvoiceUsecase, authSecret string) *InvoiceHandler {
+func NewInvoiceHandler(invUC usecase.InvoiceUsecase, authSecret, issuer, audience string) *InvoiceHandler {
 	return &InvoiceHandler{
-		invUC:      invUC,
-		authSecret: authSecret,
+		invUC:       invUC,
+		authSecret:  authSecret,
+		jwtIssuer:   issuer,
+		jwtAudience: audience,
 	}
 }
 
@@ -58,7 +62,7 @@ func (h *InvoiceHandler) List(c *fiber.Ctx) error {
 }
 
 func (h *InvoiceHandler) RegisterRoutes(app *fiber.App) {
-	api := app.Group("/invoices", middleware.JWTMiddleware(h.authSecret))
+	api := app.Group("/invoices", middleware.JWTMiddleware(h.authSecret, h.jwtIssuer, h.jwtAudience), middleware.RequireRoles("user", "admin"))
 	api.Post("/", h.Create)
 	api.Get("/", h.List)
 	api.Get("/:id", h.GetByID)

--- a/pkg/infrastructure/db.go
+++ b/pkg/infrastructure/db.go
@@ -32,6 +32,8 @@ type AppConfig struct {
 	Database DBConfig `yaml:"database"`
 	Auth     struct {
 		JWTSecret             string `yaml:"jwt_secret"`
+		JWTIssuer             string `yaml:"jwt_issuer"`
+		JWTAudience           string `yaml:"jwt_audience"`
 		JWTExpiryAccessMin    int    `yaml:"jwt_expiry_access_minutes"`
 		JWTExpiryRefreshHours int    `yaml:"jwt_expiry_refresh_hours"`
 	} `yaml:"auth"`
@@ -76,6 +78,12 @@ func LoadConfig(path string) (*AppConfig, error) {
 	// สำหรับ JWT secret
 	if env := os.Getenv("JWT_SECRET"); env != "" {
 		cfg.Auth.JWTSecret = env
+	}
+	if env := os.Getenv("JWT_ISSUER"); env != "" {
+		cfg.Auth.JWTIssuer = env
+	}
+	if env := os.Getenv("JWT_AUDIENCE"); env != "" {
+		cfg.Auth.JWTAudience = env
 	}
 	if env := os.Getenv("JWT_EXPIRY_ACCESS"); env != "" {
 		fmt.Sscanf(env, "%d", &cfg.Auth.JWTExpiryAccessMin)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -8,11 +8,15 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
-// GenerateJWTWithExpiry สร้าง JWT ระบุอายุเป็น duration ได้
-func GenerateJWTWithExpiry(secret string, userID uint, username string, expiry time.Duration) (string, error) {
+// GenerateJWTWithExpiry creates a JWT containing the user's ID, username,
+// role, issuer and audience. The token expires after the given duration.
+func GenerateJWTWithExpiry(secret string, userID uint, username, role, issuer string, audience []string, expiry time.Duration) (string, error) {
 	claims := jwt.MapClaims{
 		"user_id":  userID,
 		"username": username,
+		"role":     role,
+		"iss":      issuer,
+		"aud":      audience,
 		"exp":      time.Now().Add(expiry).Unix(),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -20,7 +24,7 @@ func GenerateJWTWithExpiry(secret string, userID uint, username string, expiry t
 }
 
 // JWTMiddleware เช็ค Access Token จาก Header
-func JWTMiddleware(secret string) fiber.Handler {
+func JWTMiddleware(secret, issuer, audience string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		authHeader := c.Get("Authorization")
 		if authHeader == "" {
@@ -41,9 +45,41 @@ func JWTMiddleware(secret string) fiber.Handler {
 			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid or expired token"})
 		}
 		claims := token.Claims.(jwt.MapClaims)
-		// อ่าน user_id จาก claims ใส่ลง Locals
+		if issuer != "" {
+			if iss, ok := claims["iss"].(string); !ok || iss != issuer {
+				return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid token issuer"})
+			}
+		}
+		if audience != "" {
+			if aud, ok := claims["aud"]; ok {
+				switch v := aud.(type) {
+				case string:
+					if v != audience {
+						return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid token audience"})
+					}
+				case []interface{}:
+					match := false
+					for _, a := range v {
+						if str, ok := a.(string); ok && str == audience {
+							match = true
+						}
+					}
+					if !match {
+						return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid token audience"})
+					}
+				default:
+					return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid token audience"})
+				}
+			} else {
+				return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "missing token audience"})
+			}
+		}
+		// อ่าน user_id และ role จาก claims ใส่ลง Locals
 		if userID, ok := claims["user_id"].(float64); ok {
 			c.Locals("user_id", uint(userID))
+		}
+		if role, ok := claims["role"].(string); ok {
+			c.Locals("role", role)
 		}
 		c.Locals("username", claims["username"].(string))
 		return c.Next()

--- a/pkg/middleware/role.go
+++ b/pkg/middleware/role.go
@@ -1,0 +1,19 @@
+package middleware
+
+import "github.com/gofiber/fiber/v2"
+
+// RequireRoles ensures the current user has one of the allowed roles.
+func RequireRoles(roles ...string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		userRole, ok := c.Locals("role").(string)
+		if !ok {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "forbidden"})
+		}
+		for _, r := range roles {
+			if r == userRole {
+				return c.Next()
+			}
+		}
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "forbidden"})
+	}
+}


### PR DESCRIPTION
## Summary
- extend user model with role field
- include role in JWT tokens
- add middleware to enforce roles
- restrict invoice routes to user/admin roles
- document new role behavior in README
- add issuer and audience claims for JWTs, with middleware verification
- represent `aud` claim as an array

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6845ebe11fb4832799fe0e0795c556d2