### PR TITLE
Add global JWT middleware

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,6 +52,8 @@ func main() {
 
 	// Logger middleware
 	app.Use(middleware.Logger(db))
+	// Global JWT middleware except for auth routes
+	app.Use(middleware.JWTMiddlewareExcept(cfg.Auth.JWTSecret, "/auth"))
 
 	// ตระเตรียม Auth module
 	authRepository := authRepo.NewAuthRepository(db)
@@ -67,7 +69,7 @@ func main() {
 	// ตระเตรียม Invoice module
 	invoiceRepository := invRepo.NewInvoiceRepository(db)
 	invoiceUsecase := invUC.NewInvoiceUsecase(invoiceRepository)
-	invoiceHandler := invHandler.NewInvoiceHandler(invoiceUsecase, cfg.Auth.JWTSecret)
+	invoiceHandler := invHandler.NewInvoiceHandler(invoiceUsecase)
 	invoiceHandler.RegisterRoutes(app)
 
 	// สตาร์ทเซิร์ฟเวอร์

--- a/internal/invoice/delivery/http/invoice_handler.go
+++ b/internal/invoice/delivery/http/invoice_handler.go
@@ -10,14 +10,12 @@ import (
 )
 
 type InvoiceHandler struct {
-	invUC      usecase.InvoiceUsecase
-	authSecret string
+	invUC usecase.InvoiceUsecase
 }
 
-func NewInvoiceHandler(invUC usecase.InvoiceUsecase, authSecret string) *InvoiceHandler {
+func NewInvoiceHandler(invUC usecase.InvoiceUsecase) *InvoiceHandler {
 	return &InvoiceHandler{
-		invUC:      invUC,
-		authSecret: authSecret,
+		invUC: invUC,
 	}
 }
 
@@ -58,7 +56,7 @@ func (h *InvoiceHandler) List(c *fiber.Ctx) error {
 }
 
 func (h *InvoiceHandler) RegisterRoutes(app *fiber.App) {
-	api := app.Group("/invoices", middleware.JWTMiddleware(h.authSecret), middleware.RequireRoles("user", "admin"))
+	api := app.Group("/invoices", middleware.RequireRoles("user", "admin"))
 	api.Post("/", h.Create)
 	api.Get("/", h.List)
 	api.Get("/:id", h.GetByID)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -54,3 +54,19 @@ func JWTMiddleware(secret string) fiber.Handler {
 		return c.Next()
 	}
 }
+
+// JWTMiddlewareExcept returns JWT middleware that skips the check for the
+// provided path prefixes. It is useful when applying authentication globally
+// but keeping some routes (e.g. /auth) public.
+func JWTMiddlewareExcept(secret string, skip ...string) fiber.Handler {
+	base := JWTMiddleware(secret)
+	return func(c *fiber.Ctx) error {
+		path := c.Path()
+		for _, prefix := range skip {
+			if strings.HasPrefix(path, prefix) {
+				return c.Next()
+			}
+		}
+		return base(c)
+	}
+}


### PR DESCRIPTION
## Summary
- add `JWTMiddlewareExcept` that can skip certain path prefixes
- remove auth secret from invoice handler
- register JWT middleware globally in `main.go`

## Testing
- `go test ./...`
- `go vet ./...`
- `go build -o /tmp/invoiceapp ./cmd`

------
https://chatgpt.com/codex/tasks/task_e_6845f5c1eea48327bf1334612e945cb7