### PR TITLE
Fix misuse of refresh tokens in Authorization header

### DIFF
--- a/internal/auth/usecase/auth_usecase.go
+++ b/internal/auth/usecase/auth_usecase.go
@@ -88,12 +88,12 @@ func (u *authUC) Login(username, password string) (string, string, error) {
 		return "", "", errors.New("invalid credentials")
 	}
 	// สร้าง access token
-	accessToken, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Role, u.accessExpiry)
+	accessToken, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Role, u.accessExpiry, "access")
 	if err != nil {
 		return "", "", err
 	}
 	// สร้าง refresh token (random string หรือ JWT ก็ได้ ในที่นี้ใช้ JWT ง่าย ๆ)
-	refreshToken, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Role, u.refreshExpiry)
+	refreshToken, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Role, u.refreshExpiry, "refresh")
 	if err != nil {
 		return "", "", err
 	}
@@ -128,11 +128,11 @@ func (u *authUC) RefreshAccessToken(oldRefreshToken string) (string, string, err
 	}
 	// ถ้า valid ก็สร้าง access + refresh ใหม่
 	user := &existing.User
-	newAccess, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Role, u.accessExpiry)
+	newAccess, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Role, u.accessExpiry, "access")
 	if err != nil {
 		return "", "", err
 	}
-	newRefresh, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Role, u.refreshExpiry)
+	newRefresh, err := middleware.GenerateJWTWithExpiry(u.jwtSecret, user.ID, user.Role, u.refreshExpiry, "refresh")
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
## Summary
- embed `token_type` in JWT claims when issuing tokens
- update authentication usecase to specify `access` vs `refresh`
- validate the `token_type` claim in middleware to reject refresh tokens as bearer tokens

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68467d1aacbc8327b0876758f59c882f