### PR TITLE
Implement global error handler

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,8 +47,10 @@ func main() {
 		&logModel.UserLog{},
 	)
 
-	// สร้าง Fiber app
-	app := fiber.New()
+	// สร้าง Fiber app พร้อม ErrorHandler กลาง
+	app := fiber.New(fiber.Config{
+		ErrorHandler: middleware.ErrorHandler,
+	})
 
 	// Logger middleware
 	app.Use(middleware.Logger(db))

--- a/pkg/middleware/error.go
+++ b/pkg/middleware/error.go
@@ -1,0 +1,20 @@
+package middleware
+
+import "github.com/gofiber/fiber/v2"
+
+// ErrorResponse formats an error message for JSON responses.
+func ErrorResponse(message string) fiber.Map {
+	return fiber.Map{"error": message}
+}
+
+// ErrorHandler is a Fiber error handler returning JSON using ErrorResponse.
+func ErrorHandler(c *fiber.Ctx, err error) error {
+	code := fiber.StatusInternalServerError
+	if e, ok := err.(*fiber.Error); ok {
+		code = e.Code
+		if e.Message != "" {
+			err = e
+		}
+	}
+	return c.Status(code).JSON(ErrorResponse(err.Error()))
+}


### PR DESCRIPTION
## Summary
- add middleware helper with ErrorResponse and ErrorHandler
- configure Fiber to use global ErrorHandler

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6846a6fd3cf08327bfb592b5b2259a4e