### PR TITLE
Improve error handling responses

### DIFF
--- a/internal/invoice/delivery/http/invoice_handler.go
+++ b/internal/invoice/delivery/http/invoice_handler.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"invoice_project/internal/invoice/usecase"
+	"invoice_project/pkg/apperror"
 	"invoice_project/pkg/middleware"
 
 	"github.com/gofiber/fiber/v2"
@@ -22,12 +23,12 @@ func NewInvoiceHandler(invUC usecase.InvoiceUsecase) *InvoiceHandler {
 func (h *InvoiceHandler) Create(c *fiber.Ctx) error {
 	var body CreateInvoiceRequest
 	if err := c.BodyParser(&body); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid payload"})
+		return apperror.New(fiber.StatusBadRequest)
 	}
 	userID := c.Locals("user_id").(uint)
 	inv, err := h.invUC.CreateInvoice(body.Customer, body.Amount, userID)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return err
 	}
 	return c.Status(fiber.StatusCreated).JSON(inv)
 }
@@ -36,12 +37,12 @@ func (h *InvoiceHandler) GetByID(c *fiber.Ctx) error {
 	idParam := c.Params("id")
 	id, err := strconv.Atoi(idParam)
 	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid invoice ID"})
+		return apperror.New(fiber.StatusBadRequest)
 	}
 	userID := c.Locals("user_id").(uint)
 	inv, err := h.invUC.GetInvoice(uint(id), userID)
 	if err != nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+		return err
 	}
 	return c.JSON(inv)
 }
@@ -50,7 +51,7 @@ func (h *InvoiceHandler) List(c *fiber.Ctx) error {
 	userID := c.Locals("user_id").(uint)
 	invoices, err := h.invUC.ListInvoices(userID)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return err
 	}
 	return c.JSON(invoices)
 }

--- a/internal/invoice/usecase/invoice_usecase.go
+++ b/internal/invoice/usecase/invoice_usecase.go
@@ -1,10 +1,11 @@
 package usecase
 
 import (
-	"errors"
-
 	"invoice_project/internal/invoice/domain"
 	"invoice_project/internal/invoice/repository"
+	"invoice_project/pkg/apperror"
+
+	"github.com/gofiber/fiber/v2"
 )
 
 type InvoiceUsecase interface {
@@ -40,7 +41,7 @@ func (u *invoiceUC) GetInvoice(id uint, userID uint) (*domain.Invoice, error) {
 		return nil, err
 	}
 	if inv == nil || inv.CreatedByID != userID {
-		return nil, errors.New("invoice not found or unauthorized")
+		return nil, apperror.New(fiber.StatusNotFound)
 	}
 	return inv, nil
 }

--- a/pkg/apperror/apperror.go
+++ b/pkg/apperror/apperror.go
@@ -1,0 +1,28 @@
+package apperror
+
+import "github.com/gofiber/fiber/v2"
+
+// statusText holds application specific text for common HTTP status codes.
+var statusText = map[int]string{
+	fiber.StatusBadRequest:          "BAD_REQUEST",
+	fiber.StatusUnauthorized:        "UNAUTHORIZED",
+	fiber.StatusNotFound:            "NOT_FOUND",
+	fiber.StatusInternalServerError: "INTERNAL_SERVER_ERROR",
+}
+
+// StatusMessage returns the application error message for the given status code.
+func StatusMessage(code int) string {
+	if msg, ok := statusText[code]; ok {
+		return msg
+	}
+	return "UNKNOWN_ERROR"
+}
+
+// StatusError represents an error with an associated HTTP status code.
+type StatusError struct{ Code int }
+
+// Error implements the error interface using the mapped status message.
+func (e *StatusError) Error() string { return StatusMessage(e.Code) }
+
+// New creates a new StatusError with the provided status code.
+func New(code int) error { return &StatusError{Code: code} }

--- a/pkg/middleware/error.go
+++ b/pkg/middleware/error.go
@@ -1,6 +1,9 @@
 package middleware
 
-import "github.com/gofiber/fiber/v2"
+import (
+	"github.com/gofiber/fiber/v2"
+	"invoice_project/pkg/apperror"
+)
 
 // ErrorResponse formats an error message for JSON responses.
 func ErrorResponse(message string) fiber.Map {
@@ -10,11 +13,13 @@ func ErrorResponse(message string) fiber.Map {
 // ErrorHandler is a Fiber error handler returning JSON using ErrorResponse.
 func ErrorHandler(c *fiber.Ctx, err error) error {
 	code := fiber.StatusInternalServerError
-	if e, ok := err.(*fiber.Error); ok {
+	switch e := err.(type) {
+	case *apperror.StatusError:
 		code = e.Code
-		if e.Message != "" {
-			err = e
-		}
+	case *fiber.Error:
+		code = e.Code
 	}
-	return c.Status(code).JSON(ErrorResponse(err.Error()))
+
+	msg := apperror.StatusMessage(code)
+	return c.Status(code).JSON(ErrorResponse(msg))
 }


### PR DESCRIPTION
## Summary
- propagate errors with apperror for consistent JSON output
- convert usecases to return status-aware errors
- map status codes to generic messages

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6846b35f2dec832791e4d550ba63111d