### PR TITLE
Add /me profile endpoint

### DIFF
--- a/internal/auth/delivery/http/auth_handler.go
+++ b/internal/auth/delivery/http/auth_handler.go
@@ -5,6 +5,7 @@ import (
 
 	"invoice_project/internal/auth/usecase"
 	"invoice_project/pkg/apperror"
+	"invoice_project/pkg/middleware"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -81,6 +82,18 @@ func (h *AuthHandler) Logout(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"message": "logged out"})
 }
 
+func (h *AuthHandler) Me(c *fiber.Ctx) error {
+	userID, ok := c.Locals("user_id").(uint)
+	if !ok {
+		return apperror.New(fiber.StatusUnauthorized)
+	}
+	user, err := h.authUC.GetProfile(userID)
+	if err != nil {
+		return err
+	}
+	return c.JSON(user)
+}
+
 // RegisterRoutes สำหรับ auth
 func (h *AuthHandler) RegisterRoutes(app *fiber.App) {
 	apiAuth := app.Group("/auth")
@@ -88,4 +101,5 @@ func (h *AuthHandler) RegisterRoutes(app *fiber.App) {
 	apiAuth.Post("/login", h.Login)
 	apiAuth.Post("/refresh", h.Refresh)
 	apiAuth.Post("/logout", h.Logout)
+	app.Get("/me", middleware.RequireRoles("user", "admin"), h.Me)
 }

--- a/internal/auth/repository/auth_pg.go
+++ b/internal/auth/repository/auth_pg.go
@@ -12,6 +12,7 @@ import (
 type AuthRepository interface {
 	CreateUser(user *domain.User) error
 	GetUserByUsername(username string) (*domain.User, error)
+	GetUserByID(id uint) (*domain.User, error)
 	SaveRefreshToken(token *domain.RefreshToken) error
 	GetRefreshToken(rawToken string) (*domain.RefreshToken, error)
 	RevokeRefreshToken(rawToken string) error
@@ -41,6 +42,18 @@ func (r *authPG) CreateUser(user *domain.User) error {
 func (r *authPG) GetUserByUsername(username string) (*domain.User, error) {
 	var user domain.User
 	err := r.db.Where("username = ?", username).First(&user).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &user, nil
+}
+
+func (r *authPG) GetUserByID(id uint) (*domain.User, error) {
+	var user domain.User
+	err := r.db.First(&user, id).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil

--- a/internal/auth/usecase/auth_usecase.go
+++ b/internal/auth/usecase/auth_usecase.go
@@ -18,6 +18,7 @@ type AuthUsecase interface {
 	Login(username, password string) (accessToken string, refreshToken string, err error)
 	RefreshAccessToken(oldRefreshToken string) (newAccessToken string, newRefreshToken string, err error)
 	Logout(refreshToken string) error
+	GetProfile(userID uint) (*domain.User, error)
 }
 
 type authUC struct {
@@ -158,4 +159,15 @@ func (u *authUC) RefreshAccessToken(oldRefreshToken string) (string, string, err
 func (u *authUC) Logout(refreshToken string) error {
 	// ลบ refresh token ออกจาก DB เลย
 	return u.repo.RevokeRefreshToken(refreshToken)
+}
+
+func (u *authUC) GetProfile(userID uint) (*domain.User, error) {
+	user, err := u.repo.GetUserByID(userID)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, apperror.New(fiber.StatusNotFound)
+	}
+	return user, nil
 }

--- a/pkg/infrastructure/db_test.go
+++ b/pkg/infrastructure/db_test.go
@@ -52,16 +52,16 @@ server:
 
 func TestLoadConfig_EnvOverride(t *testing.T) {
 	yaml := `database:
-				host: "db"
-				port: 5432
-				user: "user"
-				password: "pass"
-				dbname: "name"
-				sslmode: "disable"
-			auth:
-				jwt_secret: "secret"
-				jwt_expiry_access_minutes: 15
-				jwt_expiry_refresh_hours: 24`
+  host: "db"
+  port: 5432
+  user: "user"
+  password: "pass"
+  dbname: "name"
+  sslmode: "disable"
+auth:
+  jwt_secret: "secret"
+  jwt_expiry_access_minutes: 15
+  jwt_expiry_refresh_hours: 24`
 	file := writeTempConfig(t, yaml)
 
 	t.Setenv("DB_HOST", "envhost")
@@ -94,16 +94,16 @@ func TestLoadConfig_JWTSecretFile(t *testing.T) {
 		t.Fatalf("failed to write secret file: %v", err)
 	}
 	yaml := `database:
-				host: "db"
-				port: 5432
-				user: "user"
-				password: "pass"
-				dbname: "name"
-				sslmode: "disable"
-			auth:
-				jwt_secret: "%s"
-				jwt_expiry_access_minutes: 15
-				jwt_expiry_refresh_hours: 24`
+  host: "db"
+  port: 5432
+  user: "user"
+  password: "pass"
+  dbname: "name"
+  sslmode: "disable"
+auth:
+  jwt_secret: "%s"
+  jwt_expiry_access_minutes: 15
+  jwt_expiry_refresh_hours: 24`
 	yaml = fmt.Sprintf(yaml, secretFile)
 	file := writeTempConfig(t, yaml)
 


### PR DESCRIPTION
## Summary
- implement `GetProfile` logic in auth usecase and repository
- expose `/me` route via `AuthHandler`
- adjust infrastructure tests YAML strings

## Testing
- `go test ./pkg/infrastructure -v`
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_684a7e65fa908327b265e24d8dec1e80