### PR TITLE
Seed default roles

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,6 +79,9 @@ func main() {
 		&logModel.UserLog{},
 	)
 
+	// Seed default roles
+	infrastructure.SeedRoles(db)
+
 	// สร้าง Fiber app พร้อม ErrorHandler กลาง
 	app := fiber.New(fiber.Config{
 		ErrorHandler: middleware.ErrorHandler,

--- a/pkg/infrastructure/seed.go
+++ b/pkg/infrastructure/seed.go
@@ -1,0 +1,35 @@
+package infrastructure
+
+import (
+	"errors"
+	"log"
+
+	"gorm.io/gorm"
+	authModel "invoice_project/internal/auth/domain"
+)
+
+// SeedRoles inserts default roles into the database if they do not already exist.
+func SeedRoles(db *gorm.DB) {
+	defaultRoles := []authModel.Role{
+		{Name: "user"},
+		{Name: "admin"},
+	}
+
+	for _, r := range defaultRoles {
+		var existing authModel.Role
+		err := db.Where("name = ?", r.Name).First(&existing).Error
+		if err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				log.Printf("failed checking role %s: %v", r.Name, err)
+				continue
+			}
+		} else {
+			// role already exists
+			continue
+		}
+
+		if err := db.Create(&r).Error; err != nil {
+			log.Printf("failed seeding role %s: %v", r.Name, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `SeedRoles` helper to populate basic roles
- call `SeedRoles` after migrations

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68539cfb29248327a374836804626da9