### PR TITLE
Fix login session insert for null IP addresses

### DIFF
--- a/internal/auth/domain/auth.go
+++ b/internal/auth/domain/auth.go
@@ -24,7 +24,7 @@ type UserSession struct {
 	ID           uint      `gorm:"primaryKey;autoIncrement"`
 	UserID       uuid.UUID `gorm:"type:uuid;not null;index"`
 	UserAgent    string    `json:"user_agent"`
-	IPAddress    string    `gorm:"type:inet" json:"ip_address"`
+	IPAddress    *string   `gorm:"type:inet" json:"ip_address"`
 	RefreshToken string    `gorm:"unique;not null"`
 	ExpiresAt    time.Time `gorm:"not null"`
 	Revoked      bool      `gorm:"default:false"`


### PR DESCRIPTION
## Summary
- allow null IP address in `UserSession`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6853c94ab7f08327b77acaa100198b08