### PR TITLE
Add revoked_at field for sessions

### DIFF
--- a/internal/auth/domain/auth.go
+++ b/internal/auth/domain/auth.go
@@ -27,7 +27,7 @@ type UserSession struct {
 	IPAddress    *string   `gorm:"type:inet" json:"ip_address"`
 	RefreshToken string    `gorm:"unique;not null"`
 	ExpiresAt    time.Time `gorm:"not null"`
-	Revoked      bool      `gorm:"default:false"`
+	RevokedAt    *time.Time
 	CreatedAt    time.Time `json:"created_at"`
 	User         User      `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"`
 }

--- a/internal/auth/usecase/auth_usecase.go
+++ b/internal/auth/usecase/auth_usecase.go
@@ -183,6 +183,9 @@ func (u *authUC) RefreshAccessToken(oldRefreshToken string) (string, string, err
 	if existing == nil {
 		return "", "", apperror.New(fiber.StatusUnauthorized)
 	}
+	if existing.RevokedAt != nil {
+		return "", "", apperror.New(fiber.StatusUnauthorized)
+	}
 	// เช็คว่า expired หรือยัง
 	if existing.ExpiresAt.Before(time.Now()) {
 		// ถ้า expired ให้ลบทิ้งและคืน error


### PR DESCRIPTION
## Summary
- store revocation time for user sessions
- fetch only active sessions when refreshing tokens
- reject refresh when token already revoked

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6853cb76fd6c8327b6b7a665feca7902