### PR TITLE
Add email availability check endpoint

### DIFF
--- a/internal/auth/delivery/http/auth_handler.go
+++ b/internal/auth/delivery/http/auth_handler.go
@@ -107,6 +107,21 @@ func (h *AuthHandler) Logout(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"message": "logged out"})
 }
 
+func (h *AuthHandler) CheckEmail(c *fiber.Ctx) error {
+	var body CheckEmailRequest
+	if err := c.BodyParser(&body); err != nil {
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	if body.Username == "" {
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	taken, err := h.authUC.IsUsernameTaken(body.Username)
+	if err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"taken": taken})
+}
+
 func (h *AuthHandler) Me(c *fiber.Ctx) error {
 	userID, ok := c.Locals("user_id").(uuid.UUID)
 	if !ok {
@@ -153,6 +168,7 @@ func (h *AuthHandler) Me(c *fiber.Ctx) error {
 func (h *AuthHandler) RegisterRoutes(app *fiber.App) {
 	apiAuth := app.Group("/auth")
 	apiAuth.Post("/register", h.Register)
+	apiAuth.Post("/check-email", h.CheckEmail)
 	apiAuth.Post("/login", h.Login)
 	apiAuth.Post("/oauth-login", h.OAuthLogin)
 	apiAuth.Post("/refresh", h.Refresh)

--- a/internal/auth/delivery/http/request.go
+++ b/internal/auth/delivery/http/request.go
@@ -28,3 +28,8 @@ type OAuthLoginRequest struct {
 type LogoutRequest struct {
 	RefreshToken string `json:"refresh_token"`
 }
+
+// CheckEmailRequest represents the payload to verify if an email is already registered.
+type CheckEmailRequest struct {
+	Username string `json:"username"`
+}


### PR DESCRIPTION
## Summary
- add CheckEmailRequest
- implement CheckEmail handler and route
- expose IsUsernameTaken in auth usecase

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6859251e1c008327a1fa7e0d3848cc05