### PR TITLE
Add MerchantType model and seed

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,6 +68,7 @@ func main() {
 		&authModel.Role{},
 		&authModel.UserRole{},
 		&invModel.Invoice{},
+		&merchModel.MerchantType{},
 		&merchModel.Merchant{},
 		&merchModel.Store{},
 		&merchModel.StoreAddress{},
@@ -87,8 +88,9 @@ func main() {
 		&logModel.UserLog{},
 	)
 
-	// Seed default roles
+	// Seed default roles and merchant types
 	infrastructure.SeedRoles(db)
+	infrastructure.SeedMerchantTypes(db)
 
 	// สร้าง Fiber app พร้อม ErrorHandler กลาง
 	app := fiber.New(fiber.Config{

--- a/internal/merchant/domain/merchant_type.go
+++ b/internal/merchant/domain/merchant_type.go
@@ -1,0 +1,7 @@
+package domain
+
+// MerchantType defines a type of merchant such as "person" or "company".
+type MerchantType struct {
+	ID   uint   `gorm:"primaryKey;autoIncrement"`
+	Name string `gorm:"size:30;unique;not null"`
+}

--- a/pkg/infrastructure/seed.go
+++ b/pkg/infrastructure/seed.go
@@ -6,6 +6,7 @@ import (
 
 	"gorm.io/gorm"
 	authModel "invoice_project/internal/auth/domain"
+	merchModel "invoice_project/internal/merchant/domain"
 )
 
 // SeedRoles inserts default roles into the database if they do not already exist.
@@ -30,6 +31,32 @@ func SeedRoles(db *gorm.DB) {
 
 		if err := db.Create(&r).Error; err != nil {
 			log.Printf("failed seeding role %s: %v", r.Name, err)
+		}
+	}
+}
+
+// SeedMerchantTypes inserts default merchant types into the database if they do not already exist.
+func SeedMerchantTypes(db *gorm.DB) {
+	defaultTypes := []merchModel.MerchantType{
+		{Name: "person"},
+		{Name: "company"},
+	}
+
+	for _, t := range defaultTypes {
+		var existing merchModel.MerchantType
+		err := db.Where("name = ?", t.Name).First(&existing).Error
+		if err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				log.Printf("failed checking merchant type %s: %v", t.Name, err)
+				continue
+			}
+		} else {
+			// type already exists
+			continue
+		}
+
+		if err := db.Create(&t).Error; err != nil {
+			log.Printf("failed seeding merchant type %s: %v", t.Name, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add `MerchantType` model to represent merchant types
- seed default merchant types
- migrate and seed merchant types on startup

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e5ce498888327a482721017b0d984