### PR TITLE
Fix duplicate merchant creation

### DIFF
--- a/internal/merchant/usecase/merchant_usecase.go
+++ b/internal/merchant/usecase/merchant_usecase.go
@@ -58,6 +58,15 @@ func (u *merchantUC) CreateMerchant(userID uuid.UUID, merchantType string) (*dom
 		return nil, apperror.New(fiber.StatusBadRequest)
 	}
 
+	// Prevent creating a merchant when a store already exists for the user.
+	hasStore, err := u.HasStore(userID)
+	if err != nil {
+		return nil, err
+	}
+	if hasStore {
+		return nil, apperror.New(fiber.StatusConflict)
+	}
+
 	mt, err := u.repo.GetMerchantTypeByName(merchantType)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- check if a user already has a store before creating a merchant

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68611a426c4483278befa903dbffb01d