### PR TITLE
Add merchant info to /me endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ export JWT_SECRET=your-jwt-secret
 The application reads `configs/config.yaml` for defaults but any environment variable above will override the values in the file.
 
 Users registered via `/auth/register` are created with the `user` role by default. Access to invoice endpoints now requires either the `user` or `admin` role.
+The `/me` endpoint returns the authenticated user's profile along with merchant details, including stores and whether the merchant is a person or company.
 
 Run the project with:
 

--- a/internal/auth/delivery/http/auth_handler.go
+++ b/internal/auth/delivery/http/auth_handler.go
@@ -152,6 +152,15 @@ func (h *AuthHandler) Me(c *fiber.Ctx) error {
 	}
 	if m != nil {
 		merchResp := fiber.Map{"merchant": m}
+
+		stores, err := h.merchantUC.ListStores(m.ID)
+		if err != nil {
+			return err
+		}
+		if len(stores) > 0 {
+			merchResp["stores"] = stores
+		}
+
 		switch m.MerchantType.Name {
 		case "person":
 			p, err := h.merchantUC.GetPerson(m.ID)
@@ -170,6 +179,7 @@ func (h *AuthHandler) Me(c *fiber.Ctx) error {
 				merchResp["company"] = comp
 			}
 		}
+
 		resp["merchant_info"] = merchResp
 	}
 


### PR DESCRIPTION
## Summary
- extend `/me` handler to include merchant stores
- document `/me` endpoint in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6861904d95b483278b0b46840495ee64