### PR TITLE
Add OTP sending route

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,8 @@ import (
 	productRepo "invoice_project/internal/product/repository"
 	productUC "invoice_project/internal/product/usecase"
 
+	"invoice_project/pkg/otp"
+
 	locationHTTP "invoice_project/internal/location/delivery/http"
 	locationModel "invoice_project/internal/location/domain"
 	locationRepo "invoice_project/internal/location/repository"
@@ -127,7 +129,8 @@ func main() {
 		cfg.Auth.JWTExpiryAccessMin,
 		cfg.Auth.JWTExpiryRefreshHours,
 	)
-	authHandler := http.NewAuthHandler(authUsecase, merchUsecase, cfg.Auth.JWTSecret)
+	otpService := otp.NewInMemoryOTPService()
+	authHandler := http.NewAuthHandler(authUsecase, merchUsecase, cfg.Auth.JWTSecret, otpService)
 	authHandler.RegisterRoutes(app)
 
 	// ตระเตรียม Invoice module

--- a/internal/auth/delivery/http/request.go
+++ b/internal/auth/delivery/http/request.go
@@ -33,3 +33,8 @@ type LogoutRequest struct {
 type CheckEmailRequest struct {
 	Username string `json:"username"`
 }
+
+// SendOTPRequest represents the payload to request an OTP to be sent.
+type SendOTPRequest struct {
+	Email string `json:"email"`
+}

--- a/pkg/otp/inmemory.go
+++ b/pkg/otp/inmemory.go
@@ -1,0 +1,41 @@
+package otp
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// InMemoryOTPService stores OTPs in memory and prints them to stdout.
+type InMemoryOTPService struct {
+	otps map[string]otpEntry
+}
+
+// NewInMemoryOTPService creates a new InMemoryOTPService instance.
+func NewInMemoryOTPService() *InMemoryOTPService {
+	return &InMemoryOTPService{otps: make(map[string]otpEntry)}
+}
+
+// SendOTP generates an OTP and logs it. It returns the generated code.
+func (s *InMemoryOTPService) SendOTP(ctx context.Context, to string) (string, error) {
+	code, err := generateCode()
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("sending OTP %s to %s\n", code, to)
+	s.otps[to] = otpEntry{Code: code, ExpiresAt: time.Now().Add(5 * time.Minute)}
+	return code, nil
+}
+
+// VerifyOTP checks the OTP code for the given receiver.
+func (s *InMemoryOTPService) VerifyOTP(to, code string) bool {
+	entry, ok := s.otps[to]
+	if !ok || time.Now().After(entry.ExpiresAt) {
+		return false
+	}
+	if entry.Code != code {
+		return false
+	}
+	delete(s.otps, to)
+	return true
+}

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -14,6 +14,13 @@ import (
 	"google.golang.org/api/option"
 )
 
+// Service defines OTP sending and verification behaviour.
+type Service interface {
+	SendOTP(ctx context.Context, to string) (string, error)
+	VerifyOTP(to, code string) bool
+}
+
+// GmailOTPService implements the Service interface using Gmail API.
 type GmailOTPService struct {
 	srv       *gmail.Service
 	fromEmail string


### PR DESCRIPTION
## Summary
- introduce OTP service interface and an in-memory implementation
- extend auth handler with SendOTP endpoint
- wire new OTP service in the main app

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6864334b82488327a7597f51943d177d