### PR TITLE
Implement SMTP OTP service

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,20 @@ export GMAIL_FROM_EMAIL=you@example.com
 
 When these values are set, the server will use Gmail to deliver OTP
 codes. Otherwise an in-memory service is used.
+
+### Using SMTP OTP Service
+
+You can also send OTP codes through a generic SMTP server. Provide the
+SMTP connection details via environment variables or `configs/config.yaml`:
+
+```bash
+export SMTP_HOST=smtp.example.com
+export SMTP_PORT=587
+export SMTP_USERNAME=user
+export SMTP_PASSWORD=pass
+export SMTP_FROM_EMAIL=noreply@example.com
+```
+
+If `SMTP_HOST` and `SMTP_FROM_EMAIL` are set, the application will use the
+SMTP service for delivering OTP codes. Gmail settings take precedence
+when provided; otherwise an in-memory service is used.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -131,7 +131,10 @@ func main() {
 		cfg.Auth.JWTExpiryRefreshHours,
 	)
 	var otpService otp.Service
-	if cfg.Gmail.CredentialsFile != "" && cfg.Gmail.TokenFile != "" && cfg.Gmail.FromEmail != "" {
+	switch {
+	case cfg.SMTP.Host != "" && cfg.SMTP.FromEmail != "":
+		otpService = otp.NewSMTPOTPService(cfg.SMTP.Host, cfg.SMTP.Port, cfg.SMTP.Username, cfg.SMTP.Password, cfg.SMTP.FromEmail)
+	case cfg.Gmail.CredentialsFile != "" && cfg.Gmail.TokenFile != "" && cfg.Gmail.FromEmail != "":
 		creds, err := os.ReadFile(cfg.Gmail.CredentialsFile)
 		if err != nil {
 			log.Fatalf("Cannot read gmail credentials: %v", err)
@@ -145,7 +148,7 @@ func main() {
 			log.Fatalf("Cannot init gmail otp service: %v", err)
 		}
 		otpService = svc
-	} else {
+	default:
 		otpService = otp.NewInMemoryOTPService()
 	}
 	authHandler := http.NewAuthHandler(authUsecase, merchUsecase, cfg.Auth.JWTSecret, otpService)

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -22,3 +22,10 @@ gmail:
   # Path to a token JSON obtained after OAuth flow
   token_file: ""
   from_email: ""
+
+smtp:
+  host: ""
+  port: 587
+  username: ""
+  password: ""
+  from_email: ""

--- a/pkg/infrastructure/db.go
+++ b/pkg/infrastructure/db.go
@@ -41,6 +41,13 @@ type AppConfig struct {
 		TokenFile       string `yaml:"token_file"`
 		FromEmail       string `yaml:"from_email"`
 	} `yaml:"gmail"`
+	SMTP struct {
+		Host      string `yaml:"host"`
+		Port      int    `yaml:"port"`
+		Username  string `yaml:"username"`
+		Password  string `yaml:"password"`
+		FromEmail string `yaml:"from_email"`
+	} `yaml:"smtp"`
 	Server ServerConfig `yaml:"server"`
 }
 
@@ -103,6 +110,21 @@ func LoadConfig(path string) (*AppConfig, error) {
 	}
 	if env := os.Getenv("GMAIL_FROM_EMAIL"); env != "" {
 		cfg.Gmail.FromEmail = env
+	}
+	if env := os.Getenv("SMTP_HOST"); env != "" {
+		cfg.SMTP.Host = env
+	}
+	if env := os.Getenv("SMTP_PORT"); env != "" {
+		fmt.Sscanf(env, "%d", &cfg.SMTP.Port)
+	}
+	if env := os.Getenv("SMTP_USERNAME"); env != "" {
+		cfg.SMTP.Username = env
+	}
+	if env := os.Getenv("SMTP_PASSWORD"); env != "" {
+		cfg.SMTP.Password = env
+	}
+	if env := os.Getenv("SMTP_FROM_EMAIL"); env != "" {
+		cfg.SMTP.FromEmail = env
 	}
 	// If JWTSecret points to a file, read its contents
 	if cfg.Auth.JWTSecret != "" {

--- a/pkg/otp/smtp.go
+++ b/pkg/otp/smtp.go
@@ -1,0 +1,61 @@
+package otp
+
+import (
+	"context"
+	"fmt"
+	"net/smtp"
+	"time"
+)
+
+// SMTPOTPService implements the Service interface using a generic SMTP server.
+type SMTPOTPService struct {
+	host      string
+	port      int
+	username  string
+	password  string
+	fromEmail string
+	otps      map[string]otpEntry
+	sendMail  func(addr string, a smtp.Auth, from string, to []string, msg []byte) error
+}
+
+// NewSMTPOTPService creates a new SMTPOTPService instance.
+func NewSMTPOTPService(host string, port int, username, password, from string) *SMTPOTPService {
+	return &SMTPOTPService{
+		host:      host,
+		port:      port,
+		username:  username,
+		password:  password,
+		fromEmail: from,
+		otps:      make(map[string]otpEntry),
+		sendMail:  smtp.SendMail,
+	}
+}
+
+// SendOTP generates an OTP code and delivers it using SMTP.
+func (s *SMTPOTPService) SendOTP(ctx context.Context, to string) (string, error) {
+	code, err := generateCode()
+	if err != nil {
+		return "", err
+	}
+	addr := fmt.Sprintf("%s:%d", s.host, s.port)
+	auth := smtp.PlainAuth("", s.username, s.password, s.host)
+	msg := []byte(fmt.Sprintf("To: %s\r\nSubject: Your OTP Code\r\n\r\nYour OTP is %s", to, code))
+	if err := s.sendMail(addr, auth, s.fromEmail, []string{to}, msg); err != nil {
+		return "", err
+	}
+	s.otps[to] = otpEntry{Code: code, ExpiresAt: time.Now().Add(5 * time.Minute)}
+	return code, nil
+}
+
+// VerifyOTP verifies the code for the given recipient.
+func (s *SMTPOTPService) VerifyOTP(to, code string) bool {
+	entry, ok := s.otps[to]
+	if !ok || time.Now().After(entry.ExpiresAt) {
+		return false
+	}
+	if entry.Code != code {
+		return false
+	}
+	delete(s.otps, to)
+	return true
+}

--- a/pkg/otp/smtp_test.go
+++ b/pkg/otp/smtp_test.go
@@ -1,0 +1,46 @@
+package otp
+
+import (
+	"context"
+	"net/smtp"
+	"testing"
+	"time"
+)
+
+func TestSMTPSendOTP(t *testing.T) {
+	var sent bool
+	svc := NewSMTPOTPService("smtp.example.com", 587, "user", "pass", "from@example.com")
+	svc.sendMail = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		sent = true
+		return nil
+	}
+	code, err := svc.SendOTP(context.Background(), "to@example.com")
+	if err != nil {
+		t.Fatalf("SendOTP returned error: %v", err)
+	}
+	if len(code) != 6 {
+		t.Errorf("expected code length 6, got %d", len(code))
+	}
+	if !sent {
+		t.Errorf("sendMail not called")
+	}
+	if _, ok := svc.otps["to@example.com"]; !ok {
+		t.Errorf("OTP not stored")
+	}
+}
+
+func TestSMTPVerifyOTP(t *testing.T) {
+	svc := &SMTPOTPService{otps: make(map[string]otpEntry)}
+	svc.otps["user@example.com"] = otpEntry{Code: "123456", ExpiresAt: time.Now().Add(1 * time.Minute)}
+
+	if !svc.VerifyOTP("user@example.com", "123456") {
+		t.Errorf("expected OTP verification success")
+	}
+	if svc.VerifyOTP("user@example.com", "123456") {
+		t.Errorf("OTP should not verify twice")
+	}
+	svc.otps["user2@example.com"] = otpEntry{Code: "999999", ExpiresAt: time.Now().Add(-1 * time.Minute)}
+	if svc.VerifyOTP("user2@example.com", "999999") {
+		t.Errorf("expired OTP should fail")
+	}
+}


### PR DESCRIPTION
## Summary
- add `SMTPOTPService` for sending OTP codes via SMTP
- wire SMTP config and environment variables
- prefer SMTP OTP, fallback to Gmail OTP, then in-memory
- document SMTP usage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686449aeb27c832780153774e7c94601