### PR TITLE
Add HTML OTP email template

### DIFF
--- a/pkg/otp/email_template.go
+++ b/pkg/otp/email_template.go
@@ -1,0 +1,23 @@
+package otp
+
+import "fmt"
+
+func buildOTPEmail(to, code string) string {
+	return fmt.Sprintf("To: %s\r\nSubject: Your OTP Code\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=\"UTF-8\"\r\n\r\n"+
+		`<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { font-family: Arial, sans-serif; background-color: #f7f7f7; padding: 20px; }
+.container { max-width: 600px; margin: auto; background-color: #ffffff; padding: 20px; border-radius: 4px; text-align: center; }
+.code { font-size: 32px; font-weight: bold; letter-spacing: 4px; }
+</style>
+</head>
+<body>
+  <div class="container">
+    <p>Your OTP code is:</p>
+    <p class="code">%s</p>
+  </div>
+</body>
+</html>`, to, code)
+}

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -63,7 +63,7 @@ func (g *GmailOTPService) SendOTP(ctx context.Context, to string) (string, error
 	if err != nil {
 		return "", err
 	}
-	msgStr := fmt.Sprintf("To: %s\r\nSubject: Your OTP Code\r\n\r\nYour OTP is %s", to, code)
+	msgStr := buildOTPEmail(to, code)
 	msg := &gmail.Message{Raw: base64.URLEncoding.EncodeToString([]byte(msgStr))}
 	if _, err := g.srv.Users.Messages.Send("me", msg).Do(); err != nil {
 		return "", err

--- a/pkg/otp/smtp.go
+++ b/pkg/otp/smtp.go
@@ -39,7 +39,7 @@ func (s *SMTPOTPService) SendOTP(ctx context.Context, to string) (string, error)
 	}
 	addr := fmt.Sprintf("%s:%d", s.host, s.port)
 	auth := smtp.PlainAuth("", s.username, s.password, s.host)
-	msg := []byte(fmt.Sprintf("To: %s\r\nSubject: Your OTP Code\r\n\r\nYour OTP is %s", to, code))
+	msg := []byte(buildOTPEmail(to, code))
 	if err := s.sendMail(addr, auth, s.fromEmail, []string{to}, msg); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- create HTML OTP email template with simple CSS
- use template when sending OTP via Gmail or SMTP

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686458d565a88327804f913b69baa7ef