### PR TITLE
Add OTP table model

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,6 +70,7 @@ func main() {
 		&authModel.UserLoginMethod{},
 		&authModel.Role{},
 		&authModel.UserRole{},
+		&authModel.OTP{},
 		&invModel.Invoice{},
 		&merchModel.MerchantType{},
 		&merchModel.Merchant{},

--- a/internal/auth/domain/otp.go
+++ b/internal/auth/domain/otp.go
@@ -1,0 +1,23 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// OTP stores a hashed OTP code and metadata for verification attempts.
+type OTP struct {
+	ID          uint64    `gorm:"primaryKey;autoIncrement"`
+	UserID      uuid.UUID `gorm:"type:uuid;not null"`
+	Purpose     string    `gorm:"type:text;not null"`
+	Destination string    `gorm:"type:text;not null"`
+	CodeHash    string    `gorm:"type:text;not null"`
+	CreatedAt   time.Time `gorm:"not null;default:now()"`
+	ExpiresAt   time.Time `gorm:"not null"`
+	UsedAt      *time.Time
+	RevokedAt   *time.Time
+	Attempts    uint16 `gorm:"not null;default:0"`
+}
+
+func (OTP) TableName() string { return "otps" }


### PR DESCRIPTION
## Summary
- define `OTP` domain model for hashed OTP codes
- register new model with AutoMigrate

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6864fed5fa4c832789024568bc3174f4