### PR TITLE
Add OTP verification endpoints using database

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -152,7 +152,9 @@ func main() {
 	default:
 		otpService = otp.NewInMemoryOTPService()
 	}
-	authHandler := http.NewAuthHandler(authUsecase, merchUsecase, cfg.Auth.JWTSecret, otpService)
+	otpRepo := authRepo.NewOTPRepository(db)
+	otpUsecase := authUC.NewOTPUsecase(authRepository, otpRepo, otpService)
+	authHandler := http.NewAuthHandler(authUsecase, merchUsecase, cfg.Auth.JWTSecret, otpUsecase)
 	authHandler.RegisterRoutes(app)
 
 	// ตระเตรียม Invoice module

--- a/internal/auth/delivery/http/request.go
+++ b/internal/auth/delivery/http/request.go
@@ -38,3 +38,9 @@ type CheckEmailRequest struct {
 type SendOTPRequest struct {
 	Email string `json:"email"`
 }
+
+// VerifyOTPRequest represents the payload for verifying an OTP code.
+type VerifyOTPRequest struct {
+	Email string `json:"email"`
+	Code  string `json:"code"`
+}

--- a/internal/auth/repository/auth_pg.go
+++ b/internal/auth/repository/auth_pg.go
@@ -23,6 +23,7 @@ type AuthRepository interface {
 	GetUserByLoginMethod(provider, providerUID string) (*domain.User, error)
 	AssignRoleToUser(userID uuid.UUID, roleName string) error
 	GetPrimaryRole(userID uuid.UUID) (string, error)
+	SetUserVerified(userID uuid.UUID) error
 }
 
 type authPG struct {
@@ -134,4 +135,8 @@ func (r *authPG) GetPrimaryRole(userID uuid.UUID) (string, error) {
 		return "", err
 	}
 	return role.Name, nil
+}
+
+func (r *authPG) SetUserVerified(userID uuid.UUID) error {
+	return r.db.Model(&domain.User{}).Where("id = ?", userID).Update("is_verified", true).Error
 }

--- a/internal/auth/repository/otp_pg.go
+++ b/internal/auth/repository/otp_pg.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"errors"
+	"time"
+
+	"invoice_project/internal/auth/domain"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// OTPRepository manages OTP persistence.
+type OTPRepository interface {
+	CreateOTP(o *domain.OTP) error
+	GetActiveOTP(userID uuid.UUID, dest, purpose string) (*domain.OTP, error)
+	MarkUsed(id uint64) error
+	IncrementAttempts(id uint64) error
+}
+
+type otpPG struct{ db *gorm.DB }
+
+// NewOTPRepository returns a PostgreSQL implementation of OTPRepository.
+func NewOTPRepository(db *gorm.DB) OTPRepository {
+	return &otpPG{db: db}
+}
+
+func (r *otpPG) CreateOTP(o *domain.OTP) error {
+	return r.db.Create(o).Error
+}
+
+func (r *otpPG) GetActiveOTP(userID uuid.UUID, dest, purpose string) (*domain.OTP, error) {
+	var otp domain.OTP
+	err := r.db.Where("user_id = ? AND destination = ? AND purpose = ? AND used_at IS NULL AND revoked_at IS NULL AND expires_at > ?",
+		userID, dest, purpose, time.Now()).Order("created_at desc").First(&otp).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &otp, nil
+}
+
+func (r *otpPG) MarkUsed(id uint64) error {
+	return r.db.Model(&domain.OTP{}).Where("id = ?", id).Update("used_at", time.Now()).Error
+}
+
+func (r *otpPG) IncrementAttempts(id uint64) error {
+	return r.db.Model(&domain.OTP{}).Where("id = ?", id).UpdateColumn("attempts", gorm.Expr("attempts + 1")).Error
+}

--- a/internal/auth/usecase/otp_usecase.go
+++ b/internal/auth/usecase/otp_usecase.go
@@ -1,0 +1,87 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"invoice_project/internal/auth/domain"
+	"invoice_project/internal/auth/repository"
+	"invoice_project/pkg/apperror"
+	"invoice_project/pkg/otp"
+
+	"github.com/gofiber/fiber/v2"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// OTPUsecase defines sending and verifying OTP codes.
+type OTPUsecase interface {
+	SendOTP(ctx context.Context, email string) error
+	VerifyOTP(ctx context.Context, email, code string) error
+}
+
+type otpUC struct {
+	authRepo repository.AuthRepository
+	otpRepo  repository.OTPRepository
+	svc      otp.Service
+}
+
+// NewOTPUsecase creates a new OTP usecase implementation.
+func NewOTPUsecase(authRepo repository.AuthRepository, otpRepo repository.OTPRepository, svc otp.Service) OTPUsecase {
+	return &otpUC{authRepo: authRepo, otpRepo: otpRepo, svc: svc}
+}
+
+const otpPurposeVerifyEmail = "verify_email"
+
+func (u *otpUC) SendOTP(ctx context.Context, email string) error {
+	user, err := u.authRepo.GetUserByUsername(email)
+	if err != nil {
+		return err
+	}
+	if user == nil {
+		return apperror.New(fiber.StatusNotFound)
+	}
+	code, err := u.svc.SendOTP(ctx, email)
+	if err != nil {
+		return err
+	}
+	hashed, err := bcrypt.GenerateFromPassword([]byte(code), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+	otp := &domain.OTP{
+		UserID:      user.ID,
+		Purpose:     otpPurposeVerifyEmail,
+		Destination: email,
+		CodeHash:    string(hashed),
+		ExpiresAt:   time.Now().Add(5 * time.Minute),
+	}
+	return u.otpRepo.CreateOTP(otp)
+}
+
+func (u *otpUC) VerifyOTP(ctx context.Context, email, code string) error {
+	user, err := u.authRepo.GetUserByUsername(email)
+	if err != nil {
+		return err
+	}
+	if user == nil {
+		return apperror.New(fiber.StatusNotFound)
+	}
+	otpRec, err := u.otpRepo.GetActiveOTP(user.ID, email, otpPurposeVerifyEmail)
+	if err != nil {
+		return err
+	}
+	if otpRec == nil {
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(otpRec.CodeHash), []byte(code)); err != nil {
+		_ = u.otpRepo.IncrementAttempts(otpRec.ID)
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	if err := u.otpRepo.MarkUsed(otpRec.ID); err != nil {
+		return err
+	}
+	if err := u.authRepo.SetUserVerified(user.ID); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- implement PostgreSQL OTP repository
- add OTP usecase for sending and verifying codes
- extend auth repository with SetUserVerified
- update auth HTTP handler with verify endpoint
- wire OTP repository/usecase in main

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6865009883dc8327ac3aaec0a3b6b562