### PR TITLE
Add ref check for OTPs

### DIFF
--- a/internal/auth/delivery/http/auth_handler.go
+++ b/internal/auth/delivery/http/auth_handler.go
@@ -129,10 +129,10 @@ func (h *AuthHandler) SendOTP(c *fiber.Ctx) error {
 	if err := c.BodyParser(&body); err != nil {
 		return apperror.New(fiber.StatusBadRequest)
 	}
-	if body.Email == "" {
+	if body.Email == "" || body.Ref == "" {
 		return apperror.New(fiber.StatusBadRequest)
 	}
-	if err := h.otpUC.SendOTP(c.Context(), body.Email); err != nil {
+	if err := h.otpUC.SendOTP(c.Context(), body.Email, body.Ref); err != nil {
 		return err
 	}
 	return c.JSON(fiber.Map{"message": "otp sent"})
@@ -143,10 +143,10 @@ func (h *AuthHandler) VerifyOTP(c *fiber.Ctx) error {
 	if err := c.BodyParser(&body); err != nil {
 		return apperror.New(fiber.StatusBadRequest)
 	}
-	if body.Email == "" || body.Code == "" {
+	if body.Email == "" || body.Code == "" || body.Ref == "" {
 		return apperror.New(fiber.StatusBadRequest)
 	}
-	if err := h.otpUC.VerifyOTP(c.Context(), body.Email, body.Code); err != nil {
+	if err := h.otpUC.VerifyOTP(c.Context(), body.Email, body.Ref, body.Code); err != nil {
 		return err
 	}
 	return c.JSON(fiber.Map{"message": "otp verified"})

--- a/internal/auth/delivery/http/request.go
+++ b/internal/auth/delivery/http/request.go
@@ -37,10 +37,12 @@ type CheckEmailRequest struct {
 // SendOTPRequest represents the payload to request an OTP to be sent.
 type SendOTPRequest struct {
 	Email string `json:"email"`
+	Ref   string `json:"ref"`
 }
 
 // VerifyOTPRequest represents the payload for verifying an OTP code.
 type VerifyOTPRequest struct {
 	Email string `json:"email"`
+	Ref   string `json:"ref"`
 	Code  string `json:"code"`
 }

--- a/internal/auth/domain/otp.go
+++ b/internal/auth/domain/otp.go
@@ -6,6 +6,7 @@ import "time"
 type OTP struct {
 	ID          uint64    `gorm:"primaryKey;autoIncrement"`
 	Purpose     string    `gorm:"type:text;not null"`
+	Ref         string    `gorm:"type:text;not null"`
 	Destination string    `gorm:"type:text;not null"`
 	CodeHash    string    `gorm:"type:text;not null"`
 	CreatedAt   time.Time `gorm:"not null;default:now()"`

--- a/internal/auth/repository/otp_pg.go
+++ b/internal/auth/repository/otp_pg.go
@@ -12,7 +12,7 @@ import (
 // OTPRepository manages OTP persistence.
 type OTPRepository interface {
 	CreateOTP(o *domain.OTP) error
-	GetActiveOTP(dest, purpose string) (*domain.OTP, error)
+	GetActiveOTP(dest, purpose, ref string) (*domain.OTP, error)
 	MarkUsed(id uint64) error
 	IncrementAttempts(id uint64) error
 	RevokeOTP(id uint64) error
@@ -29,10 +29,10 @@ func (r *otpPG) CreateOTP(o *domain.OTP) error {
 	return r.db.Create(o).Error
 }
 
-func (r *otpPG) GetActiveOTP(dest, purpose string) (*domain.OTP, error) {
+func (r *otpPG) GetActiveOTP(dest, purpose, ref string) (*domain.OTP, error) {
 	var otp domain.OTP
-	err := r.db.Where("destination = ? AND purpose = ? AND used_at IS NULL AND revoked_at IS NULL AND expires_at > ?",
-		dest, purpose, time.Now()).Order("created_at desc").First(&otp).Error
+	err := r.db.Where("destination = ? AND purpose = ? AND ref = ? AND used_at IS NULL AND revoked_at IS NULL AND expires_at > ?",
+		dest, purpose, ref, time.Now()).Order("created_at desc").First(&otp).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil


### PR DESCRIPTION
## Summary
- support `Ref` field for OTP domain
- require ref when sending and verifying OTPs
- check ref when retrieving active OTPs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68653f763d9c8327b857027be8ef15ef