### PR TITLE
OTP ref returned in SendOTP

### DIFF
--- a/internal/auth/delivery/http/auth_handler.go
+++ b/internal/auth/delivery/http/auth_handler.go
@@ -129,13 +129,14 @@ func (h *AuthHandler) SendOTP(c *fiber.Ctx) error {
 	if err := c.BodyParser(&body); err != nil {
 		return apperror.New(fiber.StatusBadRequest)
 	}
-	if body.Email == "" || body.Ref == "" {
+	if body.Email == "" {
 		return apperror.New(fiber.StatusBadRequest)
 	}
-	if err := h.otpUC.SendOTP(c.Context(), body.Email, body.Ref); err != nil {
+	ref, err := h.otpUC.SendOTP(c.Context(), body.Email)
+	if err != nil {
 		return err
 	}
-	return c.JSON(fiber.Map{"message": "otp sent"})
+	return c.JSON(fiber.Map{"message": "otp sent", "ref": ref})
 }
 
 func (h *AuthHandler) VerifyOTP(c *fiber.Ctx) error {

--- a/internal/auth/delivery/http/request.go
+++ b/internal/auth/delivery/http/request.go
@@ -37,7 +37,6 @@ type CheckEmailRequest struct {
 // SendOTPRequest represents the payload to request an OTP to be sent.
 type SendOTPRequest struct {
 	Email string `json:"email"`
-	Ref   string `json:"ref"`
 }
 
 // VerifyOTPRequest represents the payload for verifying an OTP code.


### PR DESCRIPTION
## Summary
- update SendOTPRequest to only pass email
- generate OTP reference server-side and return it in the response
- modify OTP usecase to create and return the ref

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6865415cb1888327819cf13ab6132f68