### PR TITLE
Add reference in OTP email

### DIFF
--- a/internal/auth/usecase/otp_usecase.go
+++ b/internal/auth/usecase/otp_usecase.go
@@ -42,7 +42,8 @@ func (u *otpUC) SendOTP(ctx context.Context, email string) (string, error) {
 	if user == nil {
 		return "", apperror.New(fiber.StatusNotFound)
 	}
-	code, err := u.svc.SendOTP(ctx, email)
+	ref := uuid.NewString()
+	code, err := u.svc.SendOTP(ctx, email, ref)
 	if err != nil {
 		return "", err
 	}
@@ -50,7 +51,6 @@ func (u *otpUC) SendOTP(ctx context.Context, email string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ref := uuid.NewString()
 	otp := &domain.OTP{
 		Purpose:     otpPurposeVerifyEmail,
 		Ref:         ref,

--- a/pkg/otp/email_template.go
+++ b/pkg/otp/email_template.go
@@ -2,7 +2,7 @@ package otp
 
 import "fmt"
 
-func buildOTPEmail(to, code string) string {
+func buildOTPEmail(to, code, ref string) string {
 	return fmt.Sprintf("To: %s\r\nSubject: Your OTP Code\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=\"UTF-8\"\r\n\r\n"+
 		`<!DOCTYPE html>
 <html>
@@ -65,6 +65,7 @@ func buildOTPEmail(to, code string) string {
       <p>Hello,</p>
       <p>Here is your OTP code. Please use it to complete your verification:</p>
       <div class="otp-code">%s</div>
+      <p style="margin-top:10px;">Reference: <strong>%s</strong></p>
       <p>This code will expire in 5 minutes. Do not share this code with anyone.</p>
     </div>
     <div class="footer">
@@ -72,5 +73,5 @@ func buildOTPEmail(to, code string) string {
     </div>
   </div>
 </body>
-</html>`, to, code)
+</html>`, to, code, ref)
 }

--- a/pkg/otp/inmemory.go
+++ b/pkg/otp/inmemory.go
@@ -17,12 +17,12 @@ func NewInMemoryOTPService() *InMemoryOTPService {
 }
 
 // SendOTP generates an OTP and logs it. It returns the generated code.
-func (s *InMemoryOTPService) SendOTP(ctx context.Context, to string) (string, error) {
+func (s *InMemoryOTPService) SendOTP(ctx context.Context, to, ref string) (string, error) {
 	code, err := generateCode()
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("sending OTP %s to %s\n", code, to)
+	fmt.Printf("sending OTP %s to %s with ref %s\n", code, to, ref)
 	s.otps[to] = otpEntry{Code: code, ExpiresAt: time.Now().Add(5 * time.Minute)}
 	return code, nil
 }

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -16,7 +16,7 @@ import (
 
 // Service defines OTP sending and verification behaviour.
 type Service interface {
-	SendOTP(ctx context.Context, to string) (string, error)
+	SendOTP(ctx context.Context, to, ref string) (string, error)
 	VerifyOTP(to, code string) bool
 }
 
@@ -58,12 +58,12 @@ func generateCode() (string, error) {
 	return fmt.Sprintf("%06d", n%1000000), nil
 }
 
-func (g *GmailOTPService) SendOTP(ctx context.Context, to string) (string, error) {
+func (g *GmailOTPService) SendOTP(ctx context.Context, to, ref string) (string, error) {
 	code, err := generateCode()
 	if err != nil {
 		return "", err
 	}
-	msgStr := buildOTPEmail(to, code)
+	msgStr := buildOTPEmail(to, code, ref)
 	msg := &gmail.Message{Raw: base64.URLEncoding.EncodeToString([]byte(msgStr))}
 	if _, err := g.srv.Users.Messages.Send("me", msg).Do(); err != nil {
 		return "", err

--- a/pkg/otp/smtp.go
+++ b/pkg/otp/smtp.go
@@ -32,14 +32,14 @@ func NewSMTPOTPService(host string, port int, username, password, from string) *
 }
 
 // SendOTP generates an OTP code and delivers it using SMTP.
-func (s *SMTPOTPService) SendOTP(ctx context.Context, to string) (string, error) {
+func (s *SMTPOTPService) SendOTP(ctx context.Context, to, ref string) (string, error) {
 	code, err := generateCode()
 	if err != nil {
 		return "", err
 	}
 	addr := fmt.Sprintf("%s:%d", s.host, s.port)
 	auth := smtp.PlainAuth("", s.username, s.password, s.host)
-	msg := []byte(buildOTPEmail(to, code))
+	msg := []byte(buildOTPEmail(to, code, ref))
 	if err := s.sendMail(addr, auth, s.fromEmail, []string{to}, msg); err != nil {
 		return "", err
 	}

--- a/pkg/otp/smtp_test.go
+++ b/pkg/otp/smtp_test.go
@@ -14,7 +14,7 @@ func TestSMTPSendOTP(t *testing.T) {
 		sent = true
 		return nil
 	}
-	code, err := svc.SendOTP(context.Background(), "to@example.com")
+	code, err := svc.SendOTP(context.Background(), "to@example.com", "ref123")
 	if err != nil {
 		t.Fatalf("SendOTP returned error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- include OTP reference in email template
- pass reference into OTP service implementations
- update OTP usecase to generate reference before sending
- adjust unit test for SMTP service

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6865442c96808327a89cd8c55eb3b483