### PR TITLE
Add OTP purpose handling

### DIFF
--- a/internal/auth/delivery/http/auth_handler.go
+++ b/internal/auth/delivery/http/auth_handler.go
@@ -125,32 +125,32 @@ func (h *AuthHandler) CheckEmail(c *fiber.Ctx) error {
 }
 
 func (h *AuthHandler) SendOTP(c *fiber.Ctx) error {
-	var body SendOTPRequest
-	if err := c.BodyParser(&body); err != nil {
-		return apperror.New(fiber.StatusBadRequest)
-	}
-	if body.Email == "" {
-		return apperror.New(fiber.StatusBadRequest)
-	}
-	ref, err := h.otpUC.SendOTP(c.Context(), body.Email)
-	if err != nil {
-		return err
-	}
-	return c.JSON(fiber.Map{"message": "otp sent", "ref": ref})
+        var body SendOTPRequest
+        if err := c.BodyParser(&body); err != nil {
+                return apperror.New(fiber.StatusBadRequest)
+        }
+        if body.Email == "" || body.Purpose == "" {
+                return apperror.New(fiber.StatusBadRequest)
+        }
+        ref, err := h.otpUC.SendOTP(c.Context(), body.Email, body.Purpose)
+        if err != nil {
+                return err
+        }
+        return c.JSON(fiber.Map{"message": "otp sent", "ref": ref})
 }
 
 func (h *AuthHandler) VerifyOTP(c *fiber.Ctx) error {
-	var body VerifyOTPRequest
-	if err := c.BodyParser(&body); err != nil {
-		return apperror.New(fiber.StatusBadRequest)
-	}
-	if body.Email == "" || body.Code == "" || body.Ref == "" {
-		return apperror.New(fiber.StatusBadRequest)
-	}
-	if err := h.otpUC.VerifyOTP(c.Context(), body.Email, body.Ref, body.Code); err != nil {
-		return err
-	}
-	return c.JSON(fiber.Map{"message": "otp verified"})
+        var body VerifyOTPRequest
+        if err := c.BodyParser(&body); err != nil {
+                return apperror.New(fiber.StatusBadRequest)
+        }
+        if body.Email == "" || body.Code == "" || body.Ref == "" || body.Purpose == "" {
+                return apperror.New(fiber.StatusBadRequest)
+        }
+        if err := h.otpUC.VerifyOTP(c.Context(), body.Email, body.Ref, body.Code, body.Purpose, body.NewPassword); err != nil {
+                return err
+        }
+        return c.JSON(fiber.Map{"message": "otp verified"})
 }
 
 func (h *AuthHandler) MerchantStatus(c *fiber.Ctx) error {

--- a/internal/auth/delivery/http/request.go
+++ b/internal/auth/delivery/http/request.go
@@ -36,12 +36,15 @@ type CheckEmailRequest struct {
 
 // SendOTPRequest represents the payload to request an OTP to be sent.
 type SendOTPRequest struct {
-	Email string `json:"email"`
+    Email   string `json:"email"`
+    Purpose string `json:"purpose"`
 }
 
 // VerifyOTPRequest represents the payload for verifying an OTP code.
 type VerifyOTPRequest struct {
-	Email string `json:"email"`
-	Ref   string `json:"ref"`
-	Code  string `json:"code"`
+    Email       string `json:"email"`
+    Ref         string `json:"ref"`
+    Code        string `json:"code"`
+    Purpose     string `json:"purpose"`
+    NewPassword string `json:"new_password"`
 }

--- a/internal/auth/repository/auth_pg.go
+++ b/internal/auth/repository/auth_pg.go
@@ -22,8 +22,9 @@ type AuthRepository interface {
 	CreateLoginMethod(method *domain.UserLoginMethod) error
 	GetUserByLoginMethod(provider, providerUID string) (*domain.User, error)
 	AssignRoleToUser(userID uuid.UUID, roleName string) error
-	GetPrimaryRole(userID uuid.UUID) (string, error)
-	SetUserVerified(userID uuid.UUID) error
+        GetPrimaryRole(userID uuid.UUID) (string, error)
+        SetUserVerified(userID uuid.UUID) error
+        UpdatePassword(userID uuid.UUID, password string) error
 }
 
 type authPG struct {
@@ -138,5 +139,13 @@ func (r *authPG) GetPrimaryRole(userID uuid.UUID) (string, error) {
 }
 
 func (r *authPG) SetUserVerified(userID uuid.UUID) error {
-	return r.db.Model(&domain.User{}).Where("id = ?", userID).Update("is_verified", true).Error
+        return r.db.Model(&domain.User{}).Where("id = ?", userID).Update("is_verified", true).Error
+}
+
+func (r *authPG) UpdatePassword(userID uuid.UUID, password string) error {
+        hashed, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+        if err != nil {
+                return err
+        }
+        return r.db.Model(&domain.User{}).Where("id = ?", userID).Update("password_hash", string(hashed)).Error
 }


### PR DESCRIPTION
## Summary
- expand OTP usecase to support multiple purposes like verifying email or resetting password
- include `purpose` in SendOTP and VerifyOTP HTTP payloads
- validate and forward purpose to OTP usecase
- allow resetting a user's password when OTP purpose is `reset_password`

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b8214f57483279b8c519f947fa195