### PR TITLE
Add OTP purpose validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ export GMAIL_FROM_EMAIL=you@example.com
 When these values are set, the server will use Gmail to deliver OTP
 codes. Otherwise an in-memory service is used.
 
+### OTP Purposes
+
+Requests to `/auth/send-otp` and `/auth/verify-otp` require a `purpose`
+value to indicate why the OTP was issued. Valid values are:
+
+- `verify_email` - send a code to verify a user's email address
+- `reset_password` - send a code to allow password reset
+
+Any other value will result in a `400 Bad Request` response.
+
 ### Using SMTP OTP Service
 
 You can also send OTP codes through a generic SMTP server. Provide the

--- a/internal/auth/delivery/http/request.go
+++ b/internal/auth/delivery/http/request.go
@@ -36,15 +36,15 @@ type CheckEmailRequest struct {
 
 // SendOTPRequest represents the payload to request an OTP to be sent.
 type SendOTPRequest struct {
-    Email   string `json:"email"`
-    Purpose string `json:"purpose"`
+	Email   string `json:"email"`
+	Purpose string `json:"purpose"`
 }
 
 // VerifyOTPRequest represents the payload for verifying an OTP code.
 type VerifyOTPRequest struct {
-    Email       string `json:"email"`
-    Ref         string `json:"ref"`
-    Code        string `json:"code"`
-    Purpose     string `json:"purpose"`
-    NewPassword string `json:"new_password"`
+	Email       string `json:"email"`
+	Ref         string `json:"ref"`
+	Code        string `json:"code"`
+	Purpose     string `json:"purpose"`
+	NewPassword string `json:"new_password"`
 }

--- a/internal/auth/domain/otp.go
+++ b/internal/auth/domain/otp.go
@@ -2,6 +2,26 @@ package domain
 
 import "time"
 
+// OTPPurpose specifies why an OTP was requested.
+type OTPPurpose string
+
+const (
+	// OTPPurposeVerifyEmail represents an OTP sent for email verification.
+	OTPPurposeVerifyEmail OTPPurpose = "verify_email"
+	// OTPPurposeResetPassword represents an OTP used to reset a password.
+	OTPPurposeResetPassword OTPPurpose = "reset_password"
+)
+
+// IsValidOTPPurpose reports whether p is one of the allowed OTP purposes.
+func IsValidOTPPurpose(p string) bool {
+	switch OTPPurpose(p) {
+	case OTPPurposeVerifyEmail, OTPPurposeResetPassword:
+		return true
+	default:
+		return false
+	}
+}
+
 // OTP stores a hashed OTP code and metadata for verification attempts.
 type OTP struct {
 	ID          uint64    `gorm:"primaryKey;autoIncrement"`

--- a/internal/auth/usecase/otp_usecase.go
+++ b/internal/auth/usecase/otp_usecase.go
@@ -16,8 +16,8 @@ import (
 
 // OTPUsecase defines sending and verifying OTP codes.
 type OTPUsecase interface {
-        SendOTP(ctx context.Context, email, purpose string) (string, error)
-        VerifyOTP(ctx context.Context, email, ref, code, purpose, newPassword string) error
+	SendOTP(ctx context.Context, email, purpose string) (string, error)
+	VerifyOTP(ctx context.Context, email, ref, code, purpose, newPassword string) error
 }
 
 type otpUC struct {
@@ -31,57 +31,55 @@ func NewOTPUsecase(authRepo repository.AuthRepository, otpRepo repository.OTPRep
 	return &otpUC{authRepo: authRepo, otpRepo: otpRepo, svc: svc}
 }
 
-const otpPurposeVerifyEmail = "verify_email"
-const otpPurposeResetPassword = "reset_password"
 const maxOTPAttempts = 5
 
 func (u *otpUC) SendOTP(ctx context.Context, email, purpose string) (string, error) {
-        user, err := u.authRepo.GetUserByUsername(email)
-        if err != nil {
-                return "", err
-        }
-        if user == nil {
-                return "", apperror.New(fiber.StatusNotFound)
-        }
-        if purpose != otpPurposeVerifyEmail && purpose != otpPurposeResetPassword {
-                return "", apperror.New(fiber.StatusBadRequest)
-        }
-        ref := uuid.NewString()
-        code, err := u.svc.SendOTP(ctx, email, ref)
-        if err != nil {
-                return "", err
-        }
+	user, err := u.authRepo.GetUserByUsername(email)
+	if err != nil {
+		return "", err
+	}
+	if user == nil {
+		return "", apperror.New(fiber.StatusNotFound)
+	}
+	if !domain.IsValidOTPPurpose(purpose) {
+		return "", apperror.New(fiber.StatusBadRequest)
+	}
+	ref := uuid.NewString()
+	code, err := u.svc.SendOTP(ctx, email, ref)
+	if err != nil {
+		return "", err
+	}
 	hashed, err := bcrypt.GenerateFromPassword([]byte(code), bcrypt.DefaultCost)
 	if err != nil {
 		return "", err
 	}
-        otp := &domain.OTP{
-                Purpose:     purpose,
-                Ref:         ref,
-                Destination: email,
-                CodeHash:    string(hashed),
-                ExpiresAt:   time.Now().Add(5 * time.Minute),
-        }
-        return ref, u.otpRepo.CreateOTP(otp)
+	otp := &domain.OTP{
+		Purpose:     purpose,
+		Ref:         ref,
+		Destination: email,
+		CodeHash:    string(hashed),
+		ExpiresAt:   time.Now().Add(5 * time.Minute),
+	}
+	return ref, u.otpRepo.CreateOTP(otp)
 }
 
 func (u *otpUC) VerifyOTP(ctx context.Context, email, ref, code, purpose, newPassword string) error {
-        user, err := u.authRepo.GetUserByUsername(email)
-        if err != nil {
-                return err
-        }
-        if user == nil {
-                return apperror.New(fiber.StatusNotFound)
-        }
-        if purpose != otpPurposeVerifyEmail && purpose != otpPurposeResetPassword {
-                return apperror.New(fiber.StatusBadRequest)
-        }
-        otpRec, err := u.otpRepo.GetActiveOTP(email, purpose, ref)
-        if err != nil {
-                return err
-        }
-        if otpRec == nil {
-                return apperror.New(fiber.StatusBadRequest)
+	user, err := u.authRepo.GetUserByUsername(email)
+	if err != nil {
+		return err
+	}
+	if user == nil {
+		return apperror.New(fiber.StatusNotFound)
+	}
+	if !domain.IsValidOTPPurpose(purpose) {
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	otpRec, err := u.otpRepo.GetActiveOTP(email, purpose, ref)
+	if err != nil {
+		return err
+	}
+	if otpRec == nil {
+		return apperror.New(fiber.StatusBadRequest)
 	}
 	if otpRec.Attempts >= maxOTPAttempts {
 		_ = u.otpRepo.RevokeOTP(otpRec.ID)
@@ -97,17 +95,17 @@ func (u *otpUC) VerifyOTP(ctx context.Context, email, ref, code, purpose, newPas
 	if err := u.otpRepo.MarkUsed(otpRec.ID); err != nil {
 		return err
 	}
-        if purpose == otpPurposeVerifyEmail {
-                if err := u.authRepo.SetUserVerified(user.ID); err != nil {
-                        return err
-                }
-        } else if purpose == otpPurposeResetPassword {
-                if newPassword == "" {
-                        return apperror.New(fiber.StatusBadRequest)
-                }
-                if err := u.authRepo.UpdatePassword(user.ID, newPassword); err != nil {
-                        return err
-                }
-        }
-        return nil
+	if purpose == string(domain.OTPPurposeVerifyEmail) {
+		if err := u.authRepo.SetUserVerified(user.ID); err != nil {
+			return err
+		}
+	} else if purpose == string(domain.OTPPurposeResetPassword) {
+		if newPassword == "" {
+			return apperror.New(fiber.StatusBadRequest)
+		}
+		if err := u.authRepo.UpdatePassword(user.ID, newPassword); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- define constants for OTP purposes and validation helper
- use new validation helper in OTP usecase
- document valid OTP purposes in README

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b86e3bbd48327b5d42664911110cf