### PR TITLE
Add reset password flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ value to indicate why the OTP was issued. Valid values are:
 
 Any other value will result in a `400 Bad Request` response.
 
+Once the user receives a reset password code, submit it along with the
+new password to `POST /auth/reset-password`.
+
 ### Using SMTP OTP Service
 
 You can also send OTP codes through a generic SMTP server. Provide the

--- a/internal/auth/delivery/http/auth_handler.go
+++ b/internal/auth/delivery/http/auth_handler.go
@@ -3,6 +3,7 @@ package http
 import (
 	"time"
 
+	authDomain "invoice_project/internal/auth/domain"
 	"invoice_project/internal/auth/usecase"
 	merchUC "invoice_project/internal/merchant/usecase"
 	"invoice_project/pkg/apperror"
@@ -125,32 +126,46 @@ func (h *AuthHandler) CheckEmail(c *fiber.Ctx) error {
 }
 
 func (h *AuthHandler) SendOTP(c *fiber.Ctx) error {
-        var body SendOTPRequest
-        if err := c.BodyParser(&body); err != nil {
-                return apperror.New(fiber.StatusBadRequest)
-        }
-        if body.Email == "" || body.Purpose == "" {
-                return apperror.New(fiber.StatusBadRequest)
-        }
-        ref, err := h.otpUC.SendOTP(c.Context(), body.Email, body.Purpose)
-        if err != nil {
-                return err
-        }
-        return c.JSON(fiber.Map{"message": "otp sent", "ref": ref})
+	var body SendOTPRequest
+	if err := c.BodyParser(&body); err != nil {
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	if body.Email == "" || body.Purpose == "" {
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	ref, err := h.otpUC.SendOTP(c.Context(), body.Email, body.Purpose)
+	if err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"message": "otp sent", "ref": ref})
 }
 
 func (h *AuthHandler) VerifyOTP(c *fiber.Ctx) error {
-        var body VerifyOTPRequest
-        if err := c.BodyParser(&body); err != nil {
-                return apperror.New(fiber.StatusBadRequest)
-        }
-        if body.Email == "" || body.Code == "" || body.Ref == "" || body.Purpose == "" {
-                return apperror.New(fiber.StatusBadRequest)
-        }
-        if err := h.otpUC.VerifyOTP(c.Context(), body.Email, body.Ref, body.Code, body.Purpose, body.NewPassword); err != nil {
-                return err
-        }
-        return c.JSON(fiber.Map{"message": "otp verified"})
+	var body VerifyOTPRequest
+	if err := c.BodyParser(&body); err != nil {
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	if body.Email == "" || body.Code == "" || body.Ref == "" || body.Purpose == "" {
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	if err := h.otpUC.VerifyOTP(c.Context(), body.Email, body.Ref, body.Code, body.Purpose, body.NewPassword); err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"message": "otp verified"})
+}
+
+func (h *AuthHandler) ResetPassword(c *fiber.Ctx) error {
+	var body ResetPasswordRequest
+	if err := c.BodyParser(&body); err != nil {
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	if body.Email == "" || body.Code == "" || body.Ref == "" || body.NewPassword == "" {
+		return apperror.New(fiber.StatusBadRequest)
+	}
+	if err := h.otpUC.VerifyOTP(c.Context(), body.Email, body.Ref, body.Code, string(authDomain.OTPPurposeResetPassword), body.NewPassword); err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"message": "password reset"})
 }
 
 func (h *AuthHandler) MerchantStatus(c *fiber.Ctx) error {
@@ -224,6 +239,7 @@ func (h *AuthHandler) RegisterRoutes(app *fiber.App) {
 	apiAuth.Post("/check-email", h.CheckEmail)
 	apiAuth.Post("/send-otp", h.SendOTP)
 	apiAuth.Post("/verify-otp", h.VerifyOTP)
+	apiAuth.Post("/reset-password", h.ResetPassword)
 	apiAuth.Post("/login", h.Login)
 	apiAuth.Post("/oauth-login", h.OAuthLogin)
 	apiAuth.Post("/refresh", h.Refresh)

--- a/internal/auth/delivery/http/request.go
+++ b/internal/auth/delivery/http/request.go
@@ -48,3 +48,12 @@ type VerifyOTPRequest struct {
 	Purpose     string `json:"purpose"`
 	NewPassword string `json:"new_password"`
 }
+
+// ResetPasswordRequest represents the payload for resetting a password
+// using an OTP reference and code.
+type ResetPasswordRequest struct {
+	Email       string `json:"email"`
+	Ref         string `json:"ref"`
+	Code        string `json:"code"`
+	NewPassword string `json:"new_password"`
+}


### PR DESCRIPTION
## Summary
- add `ResetPasswordRequest` struct
- add `ResetPassword` handler and route
- document password reset endpoint

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b89e21af883278ed6402ca84ea710