### PR TITLE
Send OTP on registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ export JWT_SECRET=your-jwt-secret
 
 The application reads `configs/config.yaml` for defaults but any environment variable above will override the values in the file.
 
-Users registered via `/auth/register` are created with the `user` role by default. Access to invoice endpoints now requires either the `user` or `admin` role.
+Users registered via `/auth/register` are created with the `user` role by default. After registration an OTP for the `verify_email` purpose is automatically sent to the provided email and the reference returned as `otp_ref`. Access to invoice endpoints now requires either the `user` or `admin` role.
 The `/me` endpoint returns the authenticated user's profile along with merchant details, including stores and whether the merchant is a person or company.
 
 Run the project with:

--- a/internal/auth/delivery/http/auth_handler.go
+++ b/internal/auth/delivery/http/auth_handler.go
@@ -37,7 +37,11 @@ func (h *AuthHandler) Register(c *fiber.Ctx) error {
 	if err := h.authUC.Register(body.Username, body.Password); err != nil {
 		return err
 	}
-	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"message": "user registered"})
+	ref, err := h.otpUC.SendOTP(c.Context(), body.Username, string(authDomain.OTPPurposeVerifyEmail))
+	if err != nil {
+		return err
+	}
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"message": "user registered", "otp_ref": ref})
 }
 
 func (h *AuthHandler) Login(c *fiber.Ctx) error {


### PR DESCRIPTION
## Summary
- automatically send a verification OTP when a user registers
- document the new OTP behavior in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b8f843acc8327962a665786300510