### PR TITLE
Add store address to getMe output

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ export JWT_SECRET=your-jwt-secret
 The application reads `configs/config.yaml` for defaults but any environment variable above will override the values in the file.
 
 To register, first request an OTP by POSTing to `/auth/send-otp` with `purpose` set to `verify_email` and the desired email. Then call `/auth/register` providing the email as `username`, the password, and the `otp_ref` and `otp_code` returned from the previous step. Only when the OTP is verified will the user account be created with the `user` role. Access to invoice endpoints requires either the `user` or `admin` role.
-The `/me` endpoint returns the authenticated user's profile along with merchant details, including stores and whether the merchant is a person or company.
+The `/me` endpoint returns the authenticated user's profile along with merchant details, including stores with their addresses and whether the merchant is a person or company.
 
 Run the project with:
 

--- a/internal/merchant/domain/merchant.go
+++ b/internal/merchant/domain/merchant.go
@@ -14,12 +14,13 @@ type Merchant struct {
 }
 
 type Store struct {
-	ID         uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
-	MerchantID uuid.UUID `gorm:"type:uuid;not null" json:"merchant_id"`
-	StoreName  string    `gorm:"size:255;not null" json:"store_name"`
-	BranchNo   string    `gorm:"size:10" json:"branch_no"`
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
+	ID         uuid.UUID     `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
+	MerchantID uuid.UUID     `gorm:"type:uuid;not null" json:"merchant_id"`
+	StoreName  string        `gorm:"size:255;not null" json:"store_name"`
+	BranchNo   string        `gorm:"size:10" json:"branch_no"`
+	Address    *StoreAddress `gorm:"foreignKey:StoreID" json:"address,omitempty"`
+	CreatedAt  time.Time     `json:"created_at"`
+	UpdatedAt  time.Time     `json:"updated_at"`
 }
 
 type StoreAddress struct {

--- a/internal/merchant/repository/merchant_pg.go
+++ b/internal/merchant/repository/merchant_pg.go
@@ -106,7 +106,7 @@ func (r *merchantPG) CreateStore(store *domain.Store, addr *domain.StoreAddress)
 
 func (r *merchantPG) ListStores(merchantID uuid.UUID) ([]domain.Store, error) {
 	var stores []domain.Store
-	err := r.db.Where("merchant_id = ?", merchantID).Order("created_at desc").Find(&stores).Error
+	err := r.db.Preload("Address").Where("merchant_id = ?", merchantID).Order("created_at desc").Find(&stores).Error
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- include store address when listing stores
- document addresses returned by `/me` endpoint

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68790e13941883279b72c8eb89755632