### PR TITLE
Fix invoice document creation buyer/seller fields

### DIFF
--- a/internal/invoice/usecase/document_usecase.go
+++ b/internal/invoice/usecase/document_usecase.go
@@ -27,6 +27,25 @@ func (u *documentUC) CreateDocument(ctx context.Context, doc *domain.InvoiceDocu
 		return apperror.New(fiber.StatusBadRequest)
 	}
 	doc.ID = 0
+
+	// sanitize buyer fields based on buyer type
+	switch doc.BuyerType {
+	case "company":
+		doc.BuyerFirstName = ""
+		doc.BuyerLastName = ""
+	case "person":
+		doc.BuyerCompanyName = ""
+	}
+
+	// sanitize seller fields based on seller type
+	switch doc.SellerType {
+	case "company":
+		doc.SellerFirstName = ""
+		doc.SellerLastName = ""
+	case "person":
+		doc.SellerCompanyName = ""
+	}
+
 	return u.repo.CreateDocument(ctx, doc, items)
 }
 


### PR DESCRIPTION
## Summary
- sanitize invoice document fields when creating documents
  - if buyer/seller is a company drop first/last name
  - if buyer/seller is a person drop company name

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a0f3eaaa88327b532c5a275daed57